### PR TITLE
Chore: Configure timeouts in `OkHttpClient`

### DIFF
--- a/app/src/main/java/com/eka/networking/creator/RetrofitServiceCreator.kt
+++ b/app/src/main/java/com/eka/networking/creator/RetrofitServiceCreator.kt
@@ -23,6 +23,10 @@ internal class RetrofitServiceCreator(
 
     private val okHttpClient = OkHttpClient.Builder().apply {
         connectTimeout(appConfig.apiCallTimeOutInSec, TimeUnit.SECONDS)
+        callTimeout(appConfig.apiCallTimeOutInSec, TimeUnit.SECONDS)
+        connectTimeout(appConfig.apiCallTimeOutInSec, TimeUnit.SECONDS)
+        readTimeout(appConfig.apiCallTimeOutInSec, TimeUnit.SECONDS)
+        writeTimeout(appConfig.apiCallTimeOutInSec, TimeUnit.SECONDS)
         connectionPool(
             ConnectionPool(
                 maxIdleConnections = 5,


### PR DESCRIPTION
This commit adds `callTimeout`, `connectTimeout`, `readTimeout`, and `writeTimeout` to the `OkHttpClient` configuration in `RetrofitServiceCreator`. All timeouts are set using the `apiCallTimeOutInSec` value from `appConfig`.